### PR TITLE
show base ordinal only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+.idea
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+# IntelliJ IDEs directory
 .idea
 
 # Visual Studio 2015/2017 cache/options directory

--- a/code/src/components/App.jsx
+++ b/code/src/components/App.jsx
@@ -638,6 +638,7 @@ export default class App extends React.Component {
   }
 
   openStyle = (styleObj) => {
+    this.setState({ minOrdinal: null });
     if (!styleObj.metadata || styleObj.metadata["azmaps:type"] != "Azure Maps style") {
       this.state.azureMapsExtension.configTupleIndex = "";
     }
@@ -742,6 +743,7 @@ export default class App extends React.Component {
     const {mapStyle, dirtyMapStyle, selectableLayers, openStyleTransition} = this.state;
 
     const mapProps = {
+      isMinOrdinalSet: this.state.minOrdinal !== null,
       mapStyle: (dirtyMapStyle || mapStyle),
       selectableLayers,
       openStyleTransition,

--- a/code/src/components/MapMapboxGl.jsx
+++ b/code/src/components/MapMapboxGl.jsx
@@ -218,7 +218,7 @@ export default class MapMapboxGl extends React.Component {
     })
 
     map.on("sourcedata", e => {
-      if (!e.isSourceLoaded) {
+      if (!e.isSourceLoaded || this.props.isMinOrdinalSet) {
         return;
       }
 
@@ -232,9 +232,11 @@ export default class MapMapboxGl extends React.Component {
         }
       });
 
-      this.props.onSourceDataLoad({
-        minOrdinal,
-      })
+      if (minOrdinal !== null) {
+        this.props.onSourceDataLoad({
+          minOrdinal,
+        });
+      }
     })
 
     map.on("data", e => {

--- a/code/src/components/MapMapboxGl.jsx
+++ b/code/src/components/MapMapboxGl.jsx
@@ -185,7 +185,7 @@ export default class MapMapboxGl extends React.Component {
     map.addControl(nav, 'top-right');
 
     const tmpNode = document.createElement('div');
-    
+
     const inspect = new MapboxInspect({
       popup: new MapboxGl.Popup({
         closeOnClick: false
@@ -215,6 +215,26 @@ export default class MapMapboxGl extends React.Component {
         inspect,
         zoom: map.getZoom()
       });
+    })
+
+    map.on("sourcedata", e => {
+      if (!e.isSourceLoaded) {
+        return;
+      }
+
+      let minOrdinal = null;
+      map.queryRenderedFeatures().forEach((f) => {
+        if (typeof f?.properties?.levelOrdinal !== 'number') {
+          return;
+        }
+        if (minOrdinal === null || minOrdinal > f.properties.levelOrdinal) {
+          minOrdinal = f.properties.levelOrdinal;
+        }
+      });
+
+      this.props.onSourceDataLoad({
+        minOrdinal,
+      })
     })
 
     map.on("data", e => {


### PR DESCRIPTION
Current behavior: show all features of all levels

New behavior:
- get a list of all ordinals
- find lowest ordinal
- show features of that ordinal only

related ticket https://dev.azure.com/msazure/One/_workitems/edit/17244732

https://user-images.githubusercontent.com/2423760/225575654-4742f3c0-e81e-4508-a72b-e7dc45e38433.mp4

