### PR TITLE
added style names

### DIFF
--- a/code/src/components/ModalOpen.jsx
+++ b/code/src/components/ModalOpen.jsx
@@ -348,7 +348,7 @@ export default class ModalOpen extends React.Component {
               <form onSubmit={this.onSubmitAzureMapsStyle}>
                 <div className="maputnik-style-gallery-container">
                   <p>
-                    Select the style + tileset:
+                    Select the style:
                   </p>
                   <InputSelect
                     aria-label="Azure Maps map configuration's style list."

--- a/code/src/components/ModalOpen.jsx
+++ b/code/src/components/ModalOpen.jsx
@@ -353,7 +353,7 @@ export default class ModalOpen extends React.Component {
                   <InputSelect
                     aria-label="Azure Maps map configuration's style list."
                     data-wd-key="modal:open.azuremaps.style_set_style_list"
-                    options={this.state.azMapsMapConfiguration.styleTuples.map((styleTuple, idx) => [idx, styleTuple] )}
+                    options={this.state.azMapsMapConfiguration.styleTuples.map((styleTuple, idx) => [idx, styleTuple.name] )}
                     value={this.state.azMapsConfigTupleIndex}
                     onChange={this.onChangeAzureMapsconfigTupleIndex}
                   />


### PR DESCRIPTION
current behavior:
show two guids: styleId + tilesetId

new behavior:
when there is only one layer in the layers array
show displayName when it's present, fall back to name when displayName isn't defined

when there is more than one layer
same as above + tilesetId in brackets

![Screenshot 2023-03-16 160754](https://user-images.githubusercontent.com/2423760/225627712-83a69a1f-75f4-4f5b-873a-b444e3b3e3bd.png)
![Screenshot 2023-03-16 160828](https://user-images.githubusercontent.com/2423760/225627716-d91cdc76-89e1-4fac-beeb-f5675fa6b91f.png)
