### PR TITLE
fixed a bug with mutating mapstyle state

### DIFF
--- a/code/src/components/App.jsx
+++ b/code/src/components/App.jsx
@@ -744,7 +744,7 @@ export default class App extends React.Component {
 
     const mapProps = {
       isMinOrdinalSet: this.state.minOrdinal !== null,
-      mapStyle: (dirtyMapStyle || mapStyle),
+      mapStyle: (dirtyMapStyle || {...mapStyle}),
       selectableLayers,
       openStyleTransition,
       replaceAccessTokens: (mapStyle) => {


### PR DESCRIPTION
previously mapStyle prop was passed directly by reference, like
<MapMapboxGl mapStyle={this.state.mapStyle} />

Which caused mutating and unexpected change of this.state.mapStyle.
Fixed it to pass a clone of mapStyle, so that state remains untouched.

Related ticket https://msazure.visualstudio.com/One/_workitems/edit/17757762