### PR TITLE
hide subscription key in open modal (show it as password)

### DIFF
--- a/code/src/components/InputString.jsx
+++ b/code/src/components/InputString.jsx
@@ -71,6 +71,7 @@ export default class InputString extends React.Component {
       disabled: this.props.disabled,
       className: classes.join(" "),
       style: this.props.style,
+      type: this.props.type,
       value: this.state.value === undefined ? "" : this.state.value,
       placeholder: this.props.default,
       onChange: e => {

--- a/code/src/components/ModalOpen.jsx
+++ b/code/src/components/ModalOpen.jsx
@@ -293,7 +293,7 @@ export default class ModalOpen extends React.Component {
                 <InputString
                   aria-label="Azure Maps subscription key for now. RBAC access will be implemented later."
                   data-wd-key="modal:open.azuremaps.subscription_key"
-                  type="text"
+                  type="password"
                   default="Azure Maps subscription key..."
                   value={this.state.azMapsKey}
                   onInput={this.onChangeAzureMapsSubscriptionKey}


### PR DESCRIPTION
current behavior: subscription key is shown in open modal as plain text

new behavior: subscription key is hidden (input type changed to password)

related ticket https://dev.azure.com/msazure/One/_workitems/edit/17574126