### PR TITLE
dont close modal when click on underlay

### DIFF
--- a/code/src/components/ModalOpen.jsx
+++ b/code/src/components/ModalOpen.jsx
@@ -280,6 +280,7 @@ export default class ModalOpen extends React.Component {
           isOpen={this.props.isOpen}
           onOpenToggle={() => this.onOpenToggle()}
           title={'Open style'}
+          underlayClickExits={false}
         >
           {errorElement}
           <section className="maputnik-modal-section">


### PR DESCRIPTION
current behavior: clicking on underlay closes the modal

new behavior: clicking on modal underlay does nothing

related ticket: https://dev.azure.com/msazure/One/_workitems/edit/17573991