### PR TITLE
show mapconfig id dynamically in header

### DIFF
--- a/code/src/components/App.jsx
+++ b/code/src/components/App.jsx
@@ -972,14 +972,24 @@ export default class App extends React.Component {
     });
   }
 
+  updateMapConfigId = (mapConfigId) => {
+    this.state.azureMapsExtension.mapConfigurationName = mapConfigId;
+  }
+
   render() {
     const layers = this.state.selectableLayers
     const selectedLayer = layers.length > 0 ? layers[this.state.selectedLayerIndex] : null
+    const mapData = {
+      mapId: this.state.azureMapsExtension.mapConfigurationName,
+      styleName: this.state.azureMapsExtension.styleName,
+      alias: this.state.azureMapsExtension.mapConfigurationAlias,
+    };
 
     const toolbar = <AppToolbar
       renderer={this._getRenderer()}
       mapState={this.state.mapState}
       mapStyle={this.state.mapStyle}
+      mapData={mapData}
       inspectModeEnabled={this.state.mapState === "inspect"}
       sources={this.state.sources}
       onStyleChanged={this.onStyleChanged}
@@ -1052,6 +1062,7 @@ export default class App extends React.Component {
         isOpen={this.state.isOpen.export}
         onOpenToggle={this.toggleModal.bind(this, 'export')}
         azureMapsExtension={this.state.azureMapsExtension}
+        onSuccess={this.updateMapConfigId}
       />
       <ModalOpen
         onStyleOpen={this.openStyle}

--- a/code/src/components/AppToolbar.jsx
+++ b/code/src/components/AppToolbar.jsx
@@ -1,19 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
-import {detect} from 'detect-browser';
 
-import {MdFileDownload, MdOpenInBrowser, MdSave, MdLayers} from 'react-icons/md'
-
+import {MdOpenInBrowser, MdSave, MdLayers} from 'react-icons/md'
 
 import logoImage from 'maputnik-design/logos/logo-color.svg'
 import pkgJson from '../../package.json'
-
-
-// This is required because of <https://stackoverflow.com/a/49846426>, there isn't another way to detect support that I'm aware of.
-const browser = detect();
-const colorAccessibilityFiltersEnabled = ['chrome', 'firefox'].indexOf(browser.name) > -1;
-
 
 class IconText extends React.Component {
   static propTypes = {
@@ -22,48 +13,6 @@ class IconText extends React.Component {
 
   render() {
     return <span className="maputnik-icon-text">{this.props.children}</span>
-  }
-}
-
-class ToolbarLink extends React.Component {
-  static propTypes = {
-    className: PropTypes.string,
-    children: PropTypes.node,
-    href: PropTypes.string,
-    onToggleModal: PropTypes.func,
-  }
-
-  render() {
-    return <a
-      className={classnames('maputnik-toolbar-link', this.props.className)}
-      href={this.props.href}
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      {this.props.children}
-    </a>
-  }
-}
-
-class ToolbarLinkHighlighted extends React.Component {
-  static propTypes = {
-    className: PropTypes.string,
-    children: PropTypes.node,
-    href: PropTypes.string,
-    onToggleModal: PropTypes.func
-  }
-
-  render() {
-    return <a
-      className={classnames('maputnik-toolbar-link', "maputnik-toolbar-link--highlighted", this.props.className)}
-      href={this.props.href}
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      <span className="maputnik-toolbar-link-wrapper">
-        {this.props.children}
-      </span>
-    </a>
   }
 }
 
@@ -103,6 +52,7 @@ class ToolbarAction extends React.Component {
 
 export default class AppToolbar extends React.Component {
   static propTypes = {
+    mapData: PropTypes.object.isRequired,
     mapStyle: PropTypes.object.isRequired,
     inspectModeEnabled: PropTypes.bool.isRequired,
     onStyleChanged: PropTypes.func.isRequired,
@@ -256,6 +206,13 @@ export default class AppToolbar extends React.Component {
               </select>
             </label>
           </ToolbarSelect>
+        </div>
+        <div className="maputnik-toolbar-info">
+          <div className="maputnik-toolbar-info-map-config-container">
+            {this.props.mapData.mapId && <span>Map Configuration ID   : {this.props.mapData.mapId}</span>}
+            {this.props.mapData.alias && <span>Map Configuration Alias: {this.props.mapData.alias}</span>}
+          </div>
+          {this.props.mapData.styleName && <div>Style: {this.props.mapData.styleName}</div>}
         </div>
       </div>
     </nav>

--- a/code/src/components/ModalExport.jsx
+++ b/code/src/components/ModalExport.jsx
@@ -194,6 +194,7 @@ export default class ModalExport extends React.Component {
         activeRequest: null,
         activeRequestMessage: ""
       });
+      this.props.onSuccess(mapConfigurationId);
     })
     .catch(err => {
       let errorMessage = 'Failed to upload map configuration';

--- a/code/src/libs/azure-maps-ext.js
+++ b/code/src/libs/azure-maps-ext.js
@@ -523,6 +523,9 @@ class AzureMapsExtension {
   get styleAlias() { return this._styleAlias; }
   set styleAlias(newStyleAlias) { this._styleAlias = newStyleAlias; }
 
+  get styleName() { return this._styleName; }
+  set styleName(newStyleName) { this._styleName = newStyleName; }
+
   get styleDescription() { return this._styleDescription; }
   set styleDescription(newStyleDescription) { this._styleDescription = newStyleDescription; }
 
@@ -655,6 +658,7 @@ class AzureMapsExtension {
     this._configTupleIndex = configTupleIndex;
     this._style = style;
     this._styleAlias = styleAlias;
+    this._styleName = configTupleDetails.name;
     this._styleDescription = styleDescription;
     this._tilesetMetadata = tilesetMetadata;
     this._baseMap = baseMap || "blank";

--- a/code/src/styles/_toolbar.scss
+++ b/code/src/styles/_toolbar.scss
@@ -127,7 +127,6 @@
 
 .maputnik-toolbar__actions {
   white-space: nowrap;
-  flex: 1;
   overflow-y: auto;
 }
 
@@ -153,3 +152,16 @@
   }
 }
 
+.maputnik-toolbar-info {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 16px;
+  font-family: monospace;
+  white-space: break-spaces;
+}
+
+.maputnik-toolbar-info-map-config-container {
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
show mapconfig data (id, alias and style name) in header dynamically - meaning that when it's value updates after exporting it should also update.

related ticket https://dev.azure.com/msazure/One/_workitems/edit/17907091