### PR TITLE
hid feature-state color from users

### DIFF
--- a/code/src/components/PropertyGroup.jsx
+++ b/code/src/components/PropertyGroup.jsx
@@ -48,6 +48,11 @@ export default class PropertyGroup extends React.Component {
     this.props.onChange(group , property, newValue)
   }
 
+  onConvertedColorPropertyChange = (property, newValue) => {
+    const group = getGroupName(this.props.spec, this.props.layer.type, property)
+    this.props.onChange(group , property, convertStringColorToExpression(newValue))
+  }
+
   render() {
     const {errors} = this.props;
     const fields = this.props.groupFields.map(fieldName => {
@@ -58,12 +63,15 @@ export default class PropertyGroup extends React.Component {
       const fieldValue = fieldName in paint ? paint[fieldName] : layout[fieldName]
       const fieldType = fieldName in paint ? 'paint' : 'layout';
 
+      const convertedFieldValue = isValueAColorExpression(fieldValue) ? fieldValue[2] : fieldValue;
+      const onChangeCallback = isValueAColorExpression(fieldValue) ? this.onConvertedColorPropertyChange : this.onPropertyChange;
+
       return <FieldFunction
         errors={errors}
-        onChange={this.onPropertyChange}
+        onChange={onChangeCallback}
         key={fieldName}
         fieldName={fieldName}
-        value={fieldValue}
+        value={convertedFieldValue}
         fieldType={fieldType}
         fieldSpec={fieldSpec}
       />
@@ -73,4 +81,26 @@ export default class PropertyGroup extends React.Component {
       {fields}
     </div>
   }
+}
+
+// checks if it is a color expression, like
+// [
+//   "string",
+//   ["feature-state", "color"],
+//   "rgba(255, 255, 255, 1)"
+// ]
+function isValueAColorExpression(value) {
+  return Array.isArray(value) && value.length === 3 && value[0] === 'string' && Array.isArray(value[1])
+    && value[1][0] === 'feature-state' && value[1][1] === 'color' && typeof value[2] === 'string';
+}
+
+function convertStringColorToExpression(colorString) {
+  if (typeof colorString !== 'string') {
+    return colorString;
+  }
+  return [
+    'string',
+    ['feature-state', 'color'],
+    colorString,
+  ];
 }


### PR DESCRIPTION
current behavior:
in some cases color field value is expression:
[
  "string",
  ["feature-state", "color"],
  "rgba(255, 255, 255, 1)"
]

new behavior:
feature-state is something we'd like to hide from users where possible, so in these cases it would be replaced in UI with string value and attached color picker. When user changes/saves the value it's converted back to an expression. So visually it looks like a string, but is still an expression under the hood.

related ticket: https://dev.azure.com/msazure/One/_workitems/edit/17484247